### PR TITLE
Add CryptoGainsCalc to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ An Awesome List About Everything Crypto Currency.
 ## Tools
 
 - [Coiniverse](https://www.coiniverse.info/): Collection of cryptocurrency tools
+- [CryptoGainsCalc](https://cryptogainscalc.com): Free, browser-only crypto capital gains calculator using FIFO cost-basis matching, with optional US federal / Spanish IRPF tax estimates.
 - [Ghostfolio](https://ghostfol.io/): Open source wealth management software to track cryptocurrency holdings across multiple platforms
 - [Mobula UI](https://github.com/MobulaFi/mobula-ui): Open-source coin & portfolio tracking platform
 - [RP2](https://github.com/eprbell/rp2): Privacy-focused, free, open-source crypto tax calculator supporting multiple countries


### PR DESCRIPTION
CryptoGainsCalc (https://cryptogainscalc.com) is a free crypto capital gains calculator that runs entirely client-side -- no account, no server, nothing you enter is ever sent anywhere. It matches buys/sells using FIFO cost-basis matching and splits the result into short-term vs. long-term gains, with optional tax-owed estimates for US federal filers and Spanish IRPF filers. Available in English and Spanish.

It fits the Tools section as a lightweight, privacy-first complement to the existing entries -- most crypto tax tools require an account or uploading transaction data; this one doesn't.
